### PR TITLE
Add support to retrieve reports from Etl-rest-server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+#Etl-rest-server credentials
+ETL_REST_BASE_URL=<base url>
+ETL_REST_USERNAME=<username>
+ETL_REST_PASSWORD=<password>

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,11 +82,27 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/btoa": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/btoa/-/btoa-1.2.3.tgz",
+      "integrity": "sha512-ANNCZICS/ofxhzUl8V1DniBJs+sFQ+Yg5am1ZwVEf/sxoKY/J2+h5Fuw3xUErlZ7eJLdgzukBjZwnsV6+/2Rmg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
+      "requires": {
+        "dotenv": "*"
+      }
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -103,8 +119,7 @@
     "@types/node": {
       "version": "14.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
-      "dev": true
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -322,6 +337,14 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -368,6 +391,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -613,6 +641,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -964,6 +997,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "keywords": [
     "dhis",
+    "dhis2",
     "node",
     "integration"
   ],
@@ -36,5 +37,12 @@
     "prettier": "^2.0.5",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.7"
+  },
+  "dependencies": {
+    "@types/btoa": "^1.2.3",
+    "@types/dotenv": "^8.2.0",
+    "axios": "^0.19.2",
+    "btoa": "^1.2.1",
+    "dotenv": "^8.2.0"
   }
 }

--- a/src/common/baseHttpClient.ts
+++ b/src/common/baseHttpClient.ts
@@ -1,0 +1,18 @@
+import axios, { AxiosInstance } from 'axios';
+
+export abstract class BaseHttpClient {
+	protected readonly axios: AxiosInstance;
+
+	constructor(baseURL: any) {
+		this.axios = axios.create({
+			baseURL: baseURL,
+			responseType: 'json',
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		});
+	}
+
+	protected handleError = (error: any[]): Promise<string> =>
+		Promise.reject(error);
+}

--- a/src/common/etlRestClient.ts
+++ b/src/common/etlRestClient.ts
@@ -1,0 +1,31 @@
+import { AxiosResponse, AxiosRequestConfig } from 'axios';
+import btoa from 'btoa';
+
+import { BaseHttpClient } from './baseHttpClient';
+import { ETL_BASE_URL, ETL_USERNAME, ETL_PASSWORD } from '../utils/config';
+
+const token = btoa(ETL_USERNAME + ':' + ETL_PASSWORD);
+
+export default class ETLRestClient extends BaseHttpClient {
+	constructor() {
+		super(ETL_BASE_URL);
+		this.initializeResponseInterceptor();
+		this.initializeRequestInterceptor();
+	}
+
+	private initializeResponseInterceptor = () => {
+		this.axios.interceptors.response.use(this.handleResponse, this.handleError);
+	};
+
+	private initializeRequestInterceptor = () => {
+		this.axios.interceptors.request.use(this.handleRequest, this.handleError);
+	};
+
+	private handleRequest = (config: AxiosRequestConfig) => {
+		config.headers['Authorization'] = 'Basic ' + token;
+
+		return config;
+	};
+
+	private handleResponse = ({ data }: AxiosResponse) => data;
+}

--- a/src/etl/crossBorder.resource.ts
+++ b/src/etl/crossBorder.resource.ts
@@ -1,0 +1,28 @@
+import ETLRestClient from '../common/etlRestClient';
+
+export default class CrossBorderResource extends ETLRestClient {
+	private aggregateUrl = '/hiv-summary-indicators';
+
+	public getAggregateReport(params: any): Promise<any> {
+		return this.axios
+			.get(this.constructAggregateUrl(params))
+			.then((data: any) => console.log(data))
+			.catch((error: any) => {
+				console.error(error);
+			});
+	}
+
+	private constructAggregateUrl(params: any): string {
+		return (
+			this.aggregateUrl +
+			'?endDate=' +
+			params.endDate +
+			'&startDate=' +
+			params.startDate +
+			'&locationUuids=' +
+			params.locationUuids +
+			'&indicators=' +
+			params.indicators
+		);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,14 @@
-console.log('DHIS2 Integration');
+import CrossBorderResource from './etl/crossBorder.resource';
+
+const cb = new CrossBorderResource();
+
+// to ensure it's working well
+const params = {
+	endDate: '2020-08-19T13:25:02+03:00',
+	startDate: '2020-07-19T13:25:02+03:00',
+	locationUuids: '08feae7c-1352-11df-a1f1-0026b9348838',
+	indicators:
+		'on_arvs_first_line,on_arvs,on_arvs_second_line,newly_on_second_line'
+};
+
+cb.getAggregateReport(params);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,11 @@
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const path = `${__dirname}/../../.env`;
+
+dotenv.config({ path: path });
+
+export const ETL_BASE_URL = process.env.ETL_REST_BASE_URL;
+export const ETL_USERNAME = process.env.ETL_REST_USERNAME;
+export const ETL_PASSWORD = process.env.ETL_REST_PASSWORD;


### PR DESCRIPTION
- Added ability to retrieve reports from ETL rest server
- Implement `baseHttpClient` as an abstract class to be inherited by both `ETLRestClient` and `DHISRestClient`